### PR TITLE
#1 Add option to return raw readings

### DIFF
--- a/read_sensor.py
+++ b/read_sensor.py
@@ -14,9 +14,10 @@ HUMIDITIES = deque()
 SENSOR = Adafruit_DHT.DHT22
 TEMPERATURE_GAUGE = Gauge('ambient_temperature', 'Ambient temperature')
 HUMIDITY_GAUGE = Gauge('ambient_humidity', 'Ambient humidity')
+SET_AVERAGE_READINGS = os.getenv('SET_AVERAGE_READINGS', 'true') == 'true'
 
 
-def set_average_readings(temperature, humidity):
+def set_average_readings(temperature, humidity, set_average=True):
     """
     Sets the temperature and humidity gauges with the average of the last 5 readings
     when more than 5 readings have been made.
@@ -25,35 +26,39 @@ def set_average_readings(temperature, humidity):
 
     try:
         if 0 <= humidity <= 100:
-            TEMPERATURES.appendleft(temperature)
-            HUMIDITIES.appendleft(humidity)
-            average_temperature = temperature
-            average_humidity = humidity
+            if set_average:
+                TEMPERATURES.appendleft(temperature)
+                HUMIDITIES.appendleft(humidity)
+                average_temperature = temperature
+                average_humidity = humidity
 
-            if len(TEMPERATURES) > 5:
-                TEMPERATURES.pop()
-                tmp_temperatures = list(TEMPERATURES)
+                if len(TEMPERATURES) > 5:
+                    TEMPERATURES.pop()
+                    tmp_temperatures = list(TEMPERATURES)
 
-                # Remove min/max values
-                tmp_temperatures.remove(max(tmp_temperatures))
-                tmp_temperatures.remove(min(tmp_temperatures))
+                    # Remove min/max values
+                    tmp_temperatures.remove(max(tmp_temperatures))
+                    tmp_temperatures.remove(min(tmp_temperatures))
 
-                # Get the average
-                average_temperature = sum(tmp_temperatures)/len(tmp_temperatures)
+                    # Get the average
+                    average_temperature = sum(tmp_temperatures)/len(tmp_temperatures)
 
-            if len(HUMIDITIES) > 5:
-                HUMIDITIES.pop()
-                tmp_humidities = list(HUMIDITIES)
+                if len(HUMIDITIES) > 5:
+                    HUMIDITIES.pop()
+                    tmp_humidities = list(HUMIDITIES)
 
-                # Remove min/max values
-                tmp_humidities.remove(max(tmp_humidities))
-                tmp_humidities.remove(min(tmp_humidities))
+                    # Remove min/max values
+                    tmp_humidities.remove(max(tmp_humidities))
+                    tmp_humidities.remove(min(tmp_humidities))
 
-                # Get the average
-                average_humidity = sum(tmp_humidities)/len(tmp_humidities)
+                    # Get the average
+                    average_humidity = sum(tmp_humidities)/len(tmp_humidities)
 
-            TEMPERATURE_GAUGE.set(average_temperature)
-            HUMIDITY_GAUGE.set(average_humidity)
+                TEMPERATURE_GAUGE.set(average_temperature)
+                HUMIDITY_GAUGE.set(average_humidity)
+            else:
+                TEMPERATURE_GAUGE.set(temperature)
+                HUMIDITY_GAUGE.set(humidity)
         else:
             if DEBUG:
                 print(f'Ignoring reading outside expected range: {temperature}°C, {humidity}%')
@@ -67,7 +72,7 @@ if __name__ == '__main__':
     while True:
         try:
             HUMIDITY, TEMPERATURE = Adafruit_DHT.read_retry(SENSOR, SENSOR_PIN)
-            set_average_readings(TEMPERATURE, HUMIDITY)
+            set_average_readings(TEMPERATURE, HUMIDITY, SET_AVERAGE_READINGS)
         except (ImportError, RuntimeError) as exception:
             TEMPLATE = 'An exception of type {0} occurred. Arguments:\n{1!r}'
             MESSAGE = TEMPLATE.format(type(exception).__name__, exception.args)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -39,6 +39,11 @@ def test_set_average_readings():
     assert temperature in list(read_sensor.TEMPERATURES)
     assert humidity in list(read_sensor.HUMIDITIES)
 
+    # Test with set_average set to False
+    read_sensor.set_average_readings(temperature, humidity, set_average=False)
+    assert read_sensor.TEMPERATURE_GAUGE.collect()[0].samples[0].value == 21.5
+    assert read_sensor.HUMIDITY_GAUGE.collect()[0].samples[0].value == 54
+
 
 def test_set_average_readings_with_first_reading():
     """


### PR DESCRIPTION
Resolves #1 

- [x] Add `SET_AVERAGE_READINGS` environment variable which allows raw readings to be returned

## Details

1. Set `SET_AVERAGE_READINGS=false` in your `dev.env` and note raw values are returned